### PR TITLE
Support provisioning token

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -464,14 +464,14 @@
 
         <div class="code-section">
           <div class="code-tabs">
-            <button class="code-tab active" onclick="showTab('install', this)">Install</button>
-            <button class="code-tab" onclick="showTab('events', this)">Events</button>
-            <button class="code-tab" onclick="showTab('elogs', this)">Logging</button>
-            <button class="code-tab" onclick="showTab('iot', this)">IOT</button>
-            <button class="code-tab" onclick="showTab('enrollment', this)">Enrollment</button>
-            <button class="code-tab" onclick="showTab('configmgmt', this)">Config</button>
-            <button class="code-tab" onclick="showTab('cms', this)">CMS</button>
-            <button class="code-tab" onclick="showTab('touchpoint', this)">TouchPoint</button>
+            <button class="code-tab active" onclick='showTab("install", this)'>Install</button>
+            <button class="code-tab" onclick='showTab("events", this)'>Events</button>
+            <button class="code-tab" onclick='showTab("elogs", this)'>Logging</button>
+            <button class="code-tab" onclick='showTab("iot", this)'>IOT</button>
+            <button class="code-tab" onclick='showTab("enrollment", this)'>Enrollment</button>
+            <button class="code-tab" onclick='showTab("configmgmt", this)'>Config</button>
+            <button class="code-tab" onclick='showTab("cms", this)'>CMS</button>
+            <button class="code-tab" onclick='showTab("touchpoint", this)'>TouchPoint</button>
           </div>
 
           <div class="code-content active" id="install">

--- a/lib/cms.ts
+++ b/lib/cms.ts
@@ -49,8 +49,8 @@ export class CMSClient extends BaseService {
   private allStrings: ICMS[] | null = null;
   private readonly reqHeaderNoCache = { "Cache-Control": "no-cache" };
 
-  constructor(url: string, token: string, timeout?: number) {
-    super(url, token, timeout);
+  constructor(url: string, token: string, timeout?: number, encodeToken: boolean = true) {
+    super(url, token, timeout, encodeToken);
   }
 
   /**

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -7,8 +7,8 @@ export class ConfigClient extends BaseService {
   private readonly locationId: string;
   public version?: string;
 
-  constructor(url: string, token: string, deviceId: string, locationId: string, timeout?: number) {
-    super(url, token, timeout);
+  constructor(url: string, token: string, deviceId: string, locationId: string, timeout?: number, encodeToken: boolean = true) {
+    super(url, token, timeout, encodeToken);
 
     if (!deviceId || !locationId) {
       throw new Error("Both deviceId and locationId are required");

--- a/lib/enrollment.ts
+++ b/lib/enrollment.ts
@@ -5,8 +5,8 @@ export class EnrollmentClient extends BaseService {
   private readonly fingerPrint: string;
   private started = false;
 
-  constructor(url: string, token: string, fingerPrint: string, timeout?: number) {
-    super(url, token, timeout);
+  constructor(url: string, token: string, fingerPrint: string, timeout?: number, encodeToken: boolean = true) {
+    super(url, token, timeout, encodeToken);
     if (!fingerPrint) {
       throw new Error("fingerPrint is required for Enrollment service");
     }

--- a/lib/events.ts
+++ b/lib/events.ts
@@ -6,8 +6,8 @@ export class EventsClient extends BaseService {
   private defaults: EventOptions = {};
   private debouncedEvents = new Map<number, DebouncedEvent>();
 
-  constructor(url: string, token: string, timeout?: number) {
-    super(url, token, timeout);
+  constructor(url: string, token: string, timeout?: number, encodeToken: boolean = true) {
+    super(url, token, timeout, encodeToken);
   }
 
   public setDefaults(options: EventOptions): void {

--- a/lib/iot.ts
+++ b/lib/iot.ts
@@ -43,7 +43,7 @@ export class IOTConnection extends AwaitableEmitter {
   }
 
   refreshToken(token: string): void {
-    console.log('Refresh Token');
+    console.log("Refresh Token");
     this.token = token;
     this.connect();
   }

--- a/lib/iot.ts
+++ b/lib/iot.ts
@@ -47,7 +47,7 @@ export class IOTConnection extends AwaitableEmitter {
       console.log(`Connecting to Socket.io server at ${this.url}`);
 
       this._socket = io(this.url, {
-        transports: ['websocket'],
+        transports: ["websocket"],
         query: {
           token: this.token,
           key: this.fingerPrint,

--- a/lib/logs.ts
+++ b/lib/logs.ts
@@ -8,8 +8,8 @@ export class LogsClient extends BaseService {
   private debouncer?: Debouncer<[data: LogData], Promise<ApiResponse>>;
   private lastLogHash = new Map<string, number>();
 
-  constructor(url: string, token: string, timeout?: number) {
-    super(url, token, timeout);
+  constructor(url: string, token: string, timeout?: number, encodeToken: boolean = true) {
+    super(url, token, timeout, encodeToken);
   }
 
   public setDefaults(options: LogOptions): void {

--- a/lib/shared/base.ts
+++ b/lib/shared/base.ts
@@ -5,6 +5,7 @@ export abstract class BaseService {
   private readonly requestTimeout: number;
   private readonly headers: Headers;
 
+	// encodeToken: boolean = true is for backwards compatibility until auth is standardized on the provisioning token
   protected constructor(baseUrl: string, token: string, timeout?: number, encodeToken: boolean = true) {
     if (!token) {
       throw new Error("Token is required");

--- a/lib/shared/base.ts
+++ b/lib/shared/base.ts
@@ -5,7 +5,7 @@ export abstract class BaseService {
   private readonly requestTimeout: number;
   private readonly headers: Headers;
 
-	// encodeToken: boolean = true is for backwards compatibility until auth is standardized on the provisioning token
+  // encodeToken: boolean = true is for backwards compatibility until auth is standardized on the provisioning token
   protected constructor(baseUrl: string, token: string, timeout?: number, encodeToken: boolean = true) {
     if (!token) {
       throw new Error("Token is required");

--- a/lib/shared/base.ts
+++ b/lib/shared/base.ts
@@ -5,7 +5,7 @@ export abstract class BaseService {
   private readonly requestTimeout: number;
   private readonly headers: Headers;
 
-  protected constructor(baseUrl: string, token: string, timeout?: number) {
+  protected constructor(baseUrl: string, token: string, timeout?: number, encodeToken: boolean = true) {
     if (!token) {
       throw new Error("Token is required");
     }
@@ -15,7 +15,7 @@ export abstract class BaseService {
     this.baseUrl = baseUrl;
     this.requestTimeout = timeout || 30000;
     this.headers = new Headers({
-      "Elevated-Auth": btoa(token),
+      "Elevated-Auth": encodeToken ? btoa(token) : token,
       "Content-Type": "application/json",
     });
   }

--- a/lib/touchpoint.ts
+++ b/lib/touchpoint.ts
@@ -5,8 +5,8 @@ export class TouchPointClient extends BaseService {
   private readonly fingerPrint: string;
   private touchPointId: string | null = null;
 
-  constructor(url: string, token: string, fingerPrint: string, timeout?: number) {
-    super(url, token, timeout);
+  constructor(url: string, token: string, fingerPrint: string, timeout?: number, encodeToken: boolean = true) {
+    super(url, token, timeout, encodeToken);
     if (!fingerPrint) {
       throw new Error("Device fingerprint is required for TouchPoint service");
     }


### PR DESCRIPTION
The provisioning token does not need to be base64 encoded while the subscription token does. Consumers of this library need the option to control whether or not to encode the token attached in the auth header depending on the type of token they are using.
- Add encodeToken parameter to service constructors and update related logic
- `deno fmt` updated `'` to `"` in index.html and iot.ts