### PR TITLE
Add opt-in HTTP proxy support for IOT socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -749,6 +749,17 @@ iot.disconnect();
 iot.destroy();
 ```
 
+### Proxy support
+
+Deno services behind an HTTP proxy can opt in once at startup. The factory reads `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` (and lowercase variants) and tunnels the socket.io traffic via HTTP `CONNECT`.
+
+```typescript
+import { setIOTAgentFactory } from "@eai/elevation-core-ts/iot";
+import { envProxyAgent } from "@eai/elevation-core-ts/proxy";
+
+setIOTAgentFactory(envProxyAgent);
+```
+
 ---
 
 # Device Enrollment

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@eai/elevation-core-ts",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "license": "BUSL-1.1",
   "exports": {
     ".": "./mod.ts",

--- a/deno.json
+++ b/deno.json
@@ -12,7 +12,8 @@
     "./enrollment": "./lib/enrollment.ts",
     "./config": "./lib/config.ts",
     "./touchpoint": "./lib/touchpoint.ts",
-    "./utils": "./lib/shared/utils.ts"
+    "./utils": "./lib/shared/utils.ts",
+    "./proxy": "./lib/shared/proxy.ts"
   },
   "tasks": {
     "test": "deno test --allow-net --allow-env --allow-read"

--- a/lib/iot.ts
+++ b/lib/iot.ts
@@ -58,29 +58,29 @@ export class IOTConnection extends AwaitableEmitter {
     this.connect();
   }
 
+  private buildIoOptions(): Parameters<typeof io>[1] {
+    const agent = _agentFactory ? _agentFactory(this.url) : undefined;
+    // engine.io-client narrows `agent` to string|boolean in its typings, but forwards http.Agent instances to the ws transport at runtime.
+    return {
+      transports: ["websocket"],
+      query: {
+        token: this.token,
+        key: this.fingerPrint,
+        app: this.appName,
+        version: this.appVersion,
+        secondary: this.secondary,
+      },
+      agent,
+    } as Parameters<typeof io>[1];
+  }
+
   private connect(): void {
     try {
       this.disconnect(false);
 
       console.log(`Connecting to Socket.io server at ${this.url}`);
 
-      const agent = _agentFactory ? _agentFactory(this.url) : undefined;
-
-      // engine.io-client narrows `agent` to string|boolean in its typings, but forwards http.Agent instances to the ws transport at runtime.
-      this._socket = io(
-        this.url,
-        {
-          transports: ["websocket"],
-          query: {
-            token: this.token,
-            key: this.fingerPrint,
-            app: this.appName,
-            version: this.appVersion,
-            secondary: this.secondary,
-          },
-          agent,
-        } as Parameters<typeof io>[1],
-      );
+      this._socket = io(this.url, this.buildIoOptions());
 
       this.emit("socket", this._socket);
       this.setupSocketHandlers();

--- a/lib/iot.ts
+++ b/lib/iot.ts
@@ -2,6 +2,16 @@ import { AwaitableEmitter } from "@eai/models/AwaitableEmitter";
 import { io, type Socket } from "socket.io-client";
 import type { Commands, EventData, OnlineKiosk } from "../types/mod.ts";
 
+export type IOTAgentFactory = (url: string) => unknown;
+
+let _agentFactory: IOTAgentFactory | null = null;
+
+// Set or clear a factory that produces a transport-level agent (e.g. an HTTP proxy agent) for new IOTConnection sockets.
+// Kept out of the constructor so consumers in browser bundles never pull node-only proxy code into their build.
+export function setIOTAgentFactory(factory: IOTAgentFactory | null): void {
+  _agentFactory = factory;
+}
+
 interface WebSocketError {
   message?: string;
   reason?: string;
@@ -54,16 +64,23 @@ export class IOTConnection extends AwaitableEmitter {
 
       console.log(`Connecting to Socket.io server at ${this.url}`);
 
-      this._socket = io(this.url, {
-        transports: ["websocket"],
-        query: {
-          token: this.token,
-          key: this.fingerPrint,
-          app: this.appName,
-          version: this.appVersion,
-          secondary: this.secondary,
-        },
-      });
+      const agent = _agentFactory ? _agentFactory(this.url) : undefined;
+
+      // engine.io-client narrows `agent` to string|boolean in its typings, but forwards http.Agent instances to the ws transport at runtime.
+      this._socket = io(
+        this.url,
+        {
+          transports: ["websocket"],
+          query: {
+            token: this.token,
+            key: this.fingerPrint,
+            app: this.appName,
+            version: this.appVersion,
+            secondary: this.secondary,
+          },
+          agent,
+        } as Parameters<typeof io>[1],
+      );
 
       this.emit("socket", this._socket);
       this.setupSocketHandlers();

--- a/lib/shared/proxy.ts
+++ b/lib/shared/proxy.ts
@@ -1,0 +1,142 @@
+import { Agent as HttpsAgent } from "node:https";
+import { Buffer } from "node:buffer";
+import * as net from "node:net";
+import * as tls from "node:tls";
+import type { Duplex } from "node:stream";
+
+export function resolveProxy(targetUrl: string): URL | null {
+  let target: URL;
+  try {
+    target = new URL(targetUrl);
+  }
+  catch {
+    return null;
+  }
+
+  const isSecure = target.protocol === "https:" || target.protocol === "wss:";
+
+  let proxyVar: string | undefined;
+  let noProxyVar: string | undefined;
+  try {
+    proxyVar = isSecure
+      ? Deno.env.get("HTTPS_PROXY") ?? Deno.env.get("https_proxy")
+      : Deno.env.get("HTTP_PROXY") ?? Deno.env.get("http_proxy");
+    noProxyVar = Deno.env.get("NO_PROXY") ?? Deno.env.get("no_proxy");
+  }
+  catch {
+    return null;
+  }
+
+  if (!proxyVar) return null;
+  if (noProxyVar && matchesNoProxy(target.hostname, noProxyVar)) return null;
+
+  try {
+    return new URL(proxyVar);
+  }
+  catch {
+    return null;
+  }
+}
+
+export function envProxyAgent(url: string): HttpsProxyAgent | undefined {
+  const proxyUrl = resolveProxy(url);
+  if (!proxyUrl) return undefined;
+  console.log(`Using HTTP proxy ${proxyUrl.protocol}//${proxyUrl.host}`);
+  return new HttpsProxyAgent(proxyUrl);
+}
+
+function matchesNoProxy(hostname: string, noProxy: string): boolean {
+  const lowered = hostname.toLowerCase();
+  for (const raw of noProxy.split(",")) {
+    const entry = raw.trim();
+    if (!entry) continue;
+    if (entry === "*") return true;
+    const host = entry.split(":")[0].toLowerCase().replace(/^\./, "");
+    if (lowered === host || lowered.endsWith("." + host)) return true;
+  }
+  return false;
+}
+
+export class HttpsProxyAgent extends HttpsAgent {
+  private readonly proxy: URL;
+
+  constructor(proxy: URL) {
+    super();
+    this.proxy = proxy;
+  }
+
+  // deno-lint-ignore no-explicit-any
+  override createConnection(options: any, callback?: (err: Error | null, stream: Duplex) => void): Duplex {
+    const proxyHost = this.proxy.hostname;
+    const proxyPort = Number(this.proxy.port) || (this.proxy.protocol === "https:" ? 443 : 80);
+    const proxyIsTls = this.proxy.protocol === "https:";
+
+    const proxySocket: net.Socket = proxyIsTls
+      ? tls.connect({ host: proxyHost, port: proxyPort, servername: proxyHost })
+      : net.connect({ host: proxyHost, port: proxyPort });
+
+    let buffer = Buffer.alloc(0);
+    let settled = false;
+
+    const settle = (err: Error | null, sock?: Duplex): void => {
+      if (settled) return;
+      settled = true;
+      proxySocket.removeListener("data", onData);
+      proxySocket.removeListener("error", onError);
+      proxySocket.removeListener("end", onEnd);
+      if (err) proxySocket.destroy();
+      callback?.(err, sock as Duplex);
+    };
+
+    const onData = (chunk: Buffer): void => {
+      buffer = Buffer.concat([buffer, chunk]);
+      const headerEnd = buffer.indexOf("\r\n\r\n");
+      if (headerEnd === -1) return;
+
+      const headers = buffer.subarray(0, headerEnd).toString("ascii");
+      const statusLine = headers.split("\r\n")[0];
+      const match = statusLine.match(/^HTTP\/1\.[01] (\d{3})/);
+      if (!match || match[1] !== "200") {
+        settle(new Error(`Proxy CONNECT failed: ${statusLine}`));
+        return;
+      }
+
+      // Replay any bytes that arrived after the CONNECT response so the TLS handshake sees them.
+      const leftover = buffer.subarray(headerEnd + 4);
+      if (leftover.length > 0) {
+        proxySocket.unshift(leftover);
+      }
+
+      const tlsSocket = tls.connect({
+        socket: proxySocket,
+        servername: options.servername || options.host,
+        ALPNProtocols: options.ALPNProtocols,
+      });
+      settle(null, tlsSocket);
+    };
+
+    const onError = (err: Error): void => settle(err);
+    const onEnd = (): void => settle(new Error("Proxy connection closed before CONNECT response"));
+
+    const sendConnect = (): void => {
+      const target = `${options.host}:${options.port}`;
+      const auth = this.proxy.username
+        ? `Proxy-Authorization: Basic ${btoa(`${decodeURIComponent(this.proxy.username)}:${decodeURIComponent(this.proxy.password)}`)}\r\n`
+        : "";
+      proxySocket.write(
+        `CONNECT ${target} HTTP/1.1\r\n` +
+          `Host: ${target}\r\n` +
+          auth +
+          `\r\n`,
+      );
+    };
+
+    proxySocket.once(proxyIsTls ? "secureConnect" : "connect", sendConnect);
+    proxySocket.on("data", onData);
+    proxySocket.once("error", onError);
+    proxySocket.once("end", onEnd);
+
+    // Node's http.Agent only consults the callback when createConnection returns a falsy value, so the cast is intentional.
+    return undefined as unknown as Duplex;
+  }
+}

--- a/lib/shared/proxy.ts
+++ b/lib/shared/proxy.ts
@@ -39,6 +39,16 @@ export function resolveProxy(targetUrl: string): URL | null {
 }
 
 export function envProxyAgent(url: string): HttpsProxyAgent | undefined {
+  // HttpsProxyAgent always TLS-upgrades after CONNECT, so it's only valid for wss/https targets.
+  let target: URL;
+  try {
+    target = new URL(url);
+  }
+  catch {
+    return undefined;
+  }
+  if (target.protocol !== "https:" && target.protocol !== "wss:") return undefined;
+
   const proxyUrl = resolveProxy(url);
   if (!proxyUrl) return undefined;
   console.log(`Using HTTP proxy ${proxyUrl.protocol}//${proxyUrl.host}`);

--- a/lib/shared/proxy.ts
+++ b/lib/shared/proxy.ts
@@ -30,12 +30,16 @@ export function resolveProxy(targetUrl: string): URL | null {
   if (!proxyVar) return null;
   if (noProxyVar && matchesNoProxy(target.hostname, noProxyVar)) return null;
 
+  let proxyUrl: URL;
   try {
-    return new URL(proxyVar);
+    proxyUrl = new URL(proxyVar);
   }
   catch {
     return null;
   }
+  // HttpsProxyAgent only speaks HTTP CONNECT; reject other schemes (e.g. socks5://) so misconfiguration fails clearly.
+  if (proxyUrl.protocol !== "http:" && proxyUrl.protocol !== "https:") return null;
+  return proxyUrl;
 }
 
 export function envProxyAgent(url: string): HttpsProxyAgent | undefined {
@@ -66,6 +70,8 @@ function matchesNoProxy(hostname: string, noProxy: string): boolean {
   }
   return false;
 }
+
+const MAX_CONNECT_HEADER_BYTES = 8 * 1024;
 
 export class HttpsProxyAgent extends HttpsAgent {
   private readonly proxy: URL;
@@ -101,7 +107,12 @@ export class HttpsProxyAgent extends HttpsAgent {
     const onData = (chunk: Buffer): void => {
       buffer = Buffer.concat([buffer, chunk]);
       const headerEnd = buffer.indexOf("\r\n\r\n");
-      if (headerEnd === -1) return;
+      if (headerEnd === -1) {
+        if (buffer.length > MAX_CONNECT_HEADER_BYTES) {
+          settle(new Error(`Proxy CONNECT response exceeded ${MAX_CONNECT_HEADER_BYTES} bytes without header terminator`));
+        }
+        return;
+      }
 
       const headers = buffer.subarray(0, headerEnd).toString("ascii");
       const statusLine = headers.split("\r\n")[0];
@@ -131,7 +142,9 @@ export class HttpsProxyAgent extends HttpsAgent {
     const sendConnect = (): void => {
       const target = `${options.host}:${options.port}`;
       const auth = this.proxy.username
-        ? `Proxy-Authorization: Basic ${btoa(`${decodeURIComponent(this.proxy.username)}:${decodeURIComponent(this.proxy.password)}`)}\r\n`
+        ? `Proxy-Authorization: Basic ${
+          Buffer.from(`${decodeURIComponent(this.proxy.username)}:${decodeURIComponent(this.proxy.password)}`, "utf-8").toString("base64")
+        }\r\n`
         : "";
       proxySocket.write(
         `CONNECT ${target} HTTP/1.1\r\n` +

--- a/tests/iot_test.ts
+++ b/tests/iot_test.ts
@@ -1,7 +1,11 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { assertEquals } from "@std/assert";
-import { IOTConnection } from "../lib/iot.ts";
+import { IOTConnection, setIOTAgentFactory } from "../lib/iot.ts";
 import { MockSocket } from "./_mock.ts";
+
+interface IOTOptionsBuilder {
+  buildIoOptions(): { agent?: unknown; query?: Record<string, unknown>; transports?: string[] };
+}
 
 interface IOTInternals {
   _socket: unknown;
@@ -144,6 +148,40 @@ describe("IOTConnection", () => {
       // After destroy, emitting should not trigger the listener
       iot.emit("test");
       assertEquals(called, false);
+    });
+  });
+
+  describe("setIOTAgentFactory", () => {
+    afterEach(() => setIOTAgentFactory(null));
+
+    it("agent is undefined when no factory is set", () => {
+      const [iot] = createTestIOT();
+      const opts = (iot as unknown as IOTOptionsBuilder).buildIoOptions();
+      assertEquals(opts.agent, undefined);
+    });
+
+    it("invokes the factory with the connection url and forwards the returned agent", () => {
+      const sentinel = { __id: "fake-agent" };
+      let receivedUrl: string | undefined;
+      setIOTAgentFactory((url) => {
+        receivedUrl = url;
+        return sentinel;
+      });
+
+      const [iot] = createTestIOT();
+      const opts = (iot as unknown as IOTOptionsBuilder).buildIoOptions();
+
+      assertEquals(receivedUrl, "https://iot.test.com/device");
+      assertEquals(opts.agent, sentinel);
+    });
+
+    it("clearing the factory restores undefined agent", () => {
+      setIOTAgentFactory(() => ({ __id: "x" }));
+      setIOTAgentFactory(null);
+
+      const [iot] = createTestIOT();
+      const opts = (iot as unknown as IOTOptionsBuilder).buildIoOptions();
+      assertEquals(opts.agent, undefined);
     });
   });
 });


### PR DESCRIPTION
Adds `setIOTAgentFactory()` in `lib/iot.ts` and a new `./proxy` export that ships `envProxyAgent` — a CONNECT-tunneling agent driven by `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY`. No new npm deps. Browser consumers of `/iot` are unaffected since the proxy module is a separate export.

Deno consumers opt in once at startup:

```ts
import { setIOTAgentFactory } from "@eai/elevation-core-ts/iot";
import { envProxyAgent } from "@eai/elevation-core-ts/proxy";
setIOTAgentFactory(envProxyAgent);
```